### PR TITLE
setup build scripts to publish transpiled code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+package-lock.json
 npm-debug.log*
 /coverage
 /.nyc_output

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 npm-debug.log*
 /coverage
 /.nyc_output
+/dist.js

--- a/example.js
+++ b/example.js
@@ -1,4 +1,4 @@
-const hyperFela = require('./')
+const hyperFela = require('./index')
 const h = require('hyps')
 const { createRenderer } = require('fela')
 const { render } = require('fela-dom')

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "hyper-fela",
   "version": "1.4.1",
   "description": "hyperscript-style bindings for Fela",
-  "main": "index.js",
+  "main": "dist.js",
   "scripts": {
+    "prepare": "npm run build",
+    "build": "transpilify index.js --out-file dist.js -t es2040",
     "start": "budo example:bundle.js -d example --live -- -d",
     "test:deps": "dependency-check . && dependency-check . --extra --no-dev -i es2040",
     "test:lint": "standard",
@@ -11,11 +13,6 @@
     "test:coverage": "NODE_ENV=test nyc npm run test:node",
     "test:coverage:report": "nyc report --reporter=lcov npm run test:node",
     "test": "npm-run-all -s test:node test:lint test:deps"
-  },
-  "browserify": {
-    "transform": [
-      "es2040"
-    ]
   },
   "repository": {
     "type": "git",
@@ -31,6 +28,7 @@
   "devDependencies": {
     "budo": "^9.4.7",
     "dependency-check": "^2.7.0",
+    "es2040": "^1.2.6",
     "fela": "^4.2.6",
     "fela-dom": "^4.2.6",
     "hyps": "^1.0.0",
@@ -39,10 +37,10 @@
     "nyc": "^10.1.2",
     "run-default": "^1.0.0",
     "standard": "^8.6.0",
-    "tape": "^4.6.3"
+    "tape": "^4.6.3",
+    "transpilify": "^2.0.3"
   },
   "dependencies": {
-    "es2040": "^1.2.3",
     "is-plain-object": "^2.0.1",
     "typeof-is": "^1.0.1"
   }


### PR DESCRIPTION
alternative to https://github.com/ahdinosaur/hyper-fela/pull/1 using [`transpilify`](https://github.com/ahdinosaur/transpilify). thanks @eschaefer for submitting that pull request, but figured it was easier for me to implement it using my preferred approach rather than ask for a heap of changes. :cat:

---

context on change (notes for myself):

while i prefer the [browserify approach with modules](https://gist.github.com/substack/68f8d502be42d5cd4942), where modules are published uncompiled with meta-data to describe how to transpile for the browser (`browserify.transform` field in `package.json`), it's worthwhile to support the current "modern" tool chains (webpack et al) by publishing transpiled code, especially since i expect this module will be consumed by more users who follow the "modern" approach.

side effects:

- `browserify` users will lose their source maps. i'm not sure if there's a way to inline source maps during `transpilify` in a way that will be recognized by `browserify` or `webpack` later, i haven't seen this yet in other "modern" modules.
- `main` field in `package.json` points to `dist.js`, but if we don't commit this to the repo then users won't be able to `npm install ahdinosaur/hyper-fela#master`. undecided on whether it's worth committing or not, in this case it's not much extra bloat, hmm.