### PR TITLE
passThrough props only apply when using tagName

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ document.body.appendChild(button)
 
 (optional) `options` is object with keys:
 
-- `passThrough`: a list of props that get passed to the underlying element.
+- `passThrough`: a list of props that get passed to `h` when using a `tagName`.
 
 ### `element = Element([properties], [children])`
 

--- a/index.js
+++ b/index.js
@@ -50,24 +50,27 @@ function HyperFela ({ h, renderRule }) {
       const {
         passThrough: instPassThrough = []
       } = properties
-
-      const passThrough = [
-        ...defaultPassThrough,
-        ...ctorPassThrough,
-        ...instPassThrough
-      ]
-
-      const elementProperties = passThrough
-      .reduce((sofar, key) => {
-        const value = properties[key]
-        if (!is.undefined(value)) sofar[key] = properties[key]
-        return sofar
-      }, {})
-
       const tagName = defined(properties.is, type)
-      const element = is.string(tagName)
-        ? h(tagName, elementProperties, children)
-        : type(elementProperties, children)
+
+      var element
+      if (is.string(tagName)) {
+        const passThrough = [
+          ...defaultPassThrough,
+          ...ctorPassThrough,
+          ...instPassThrough
+        ]
+
+        const tagProperties = passThrough
+        .reduce((sofar, key) => {
+          const value = properties[key]
+          if (!is.undefined(value)) sofar[key] = properties[key]
+          return sofar
+        }, {})
+
+        element = h(tagName, tagProperties, children)
+      } else {
+        element = type(properties, children)
+      }
 
       const className = renderRule(rule, properties)
 


### PR DESCRIPTION
if using a function type, expect all props to be passed down.

---

this was in my local git copy, not sure what my original use case was. :sweat_smile: